### PR TITLE
fix!: enable ThreatQuotient TLS verification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 ThreatQuotient, Inc.
+   Copyright (c) 2016-2026 ThreatQuotient, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: ThreatQ
-Copyright (c) 2016-2025 ThreatQuotient, Inc.
+Copyright (c) 2016-2026 ThreatQuotient, Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ThreatQ
 
-Publisher: ThreatQuotient \
-Connector Version: 2.4.0 \
-Product Vendor: ThreatQuotient \
-Product Name: ThreatQ \
+Publisher: ThreatQuotient <br>
+Connector Version: 2.4.0 <br>
+Product Vendor: ThreatQuotient <br>
+Product Name: ThreatQ <br>
 Minimum Product Version: 6.1.1
 
 Integrates a variety of ThreatQ services into Splunk SOAR
@@ -333,28 +333,28 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity \
-[query indicators](#action-query-indicators) - Query ThreatQ for indicator context \
-[create indicators](#action-create-indicators) - Create indicators within ThreatQ \
-[create adversaries](#action-create-adversaries) - Create adversaries within ThreatQ \
-[create custom objects](#action-create-custom-objects) - Create custom objects within ThreatQ \
-[add attribute](#action-add-attribute) - Adds an attribute to objects in ThreatQ \
-[add comment](#action-add-comment) - Adds a comment to objects in ThreatQ \
-[add tag](#action-add-tag) - Adds a tag to objects in ThreatQ \
-[set indicator status](#action-set-indicator-status) - Set a status for a given list of indicators \
-[create task](#action-create-task) - Create a task within ThreatQ \
-[create event](#action-create-event) - Create an event within ThreatQ \
-[start investigation](#action-start-investigation) - Start an investigation within ThreatQ \
-[upload spearphish](#action-upload-spearphish) - Upload a spearphish attempt to ThreatQ \
-[upload file](#action-upload-file) - Upload (and parse) a file to ThreatQ \
-[get related objects](#action-get-related-objects) - Query ThreatQ for an object's relationships \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity <br>
+[query indicators](#action-query-indicators) - Query ThreatQ for indicator context <br>
+[create indicators](#action-create-indicators) - Create indicators within ThreatQ <br>
+[create adversaries](#action-create-adversaries) - Create adversaries within ThreatQ <br>
+[create custom objects](#action-create-custom-objects) - Create custom objects within ThreatQ <br>
+[add attribute](#action-add-attribute) - Adds an attribute to objects in ThreatQ <br>
+[add comment](#action-add-comment) - Adds a comment to objects in ThreatQ <br>
+[add tag](#action-add-tag) - Adds a tag to objects in ThreatQ <br>
+[set indicator status](#action-set-indicator-status) - Set a status for a given list of indicators <br>
+[create task](#action-create-task) - Create a task within ThreatQ <br>
+[create event](#action-create-event) - Create an event within ThreatQ <br>
+[start investigation](#action-start-investigation) - Start an investigation within ThreatQ <br>
+[upload spearphish](#action-upload-spearphish) - Upload a spearphish attempt to ThreatQ <br>
+[upload file](#action-upload-file) - Upload (and parse) a file to ThreatQ <br>
+[get related objects](#action-get-related-objects) - Query ThreatQ for an object's relationships <br>
 [create signature](#action-create-signature) - Create a signature within ThreatQ
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -369,7 +369,7 @@ No Output
 
 Query ThreatQ for indicator context
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -420,7 +420,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Create indicators within ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -447,7 +447,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Create adversaries within ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -472,7 +472,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Create custom objects within ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -499,7 +499,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Adds an attribute to objects in ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -532,7 +532,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Adds a comment to objects in ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -563,7 +563,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Adds a tag to objects in ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -594,7 +594,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Set a status for a given list of indicators
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -621,7 +621,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Create a task within ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -658,7 +658,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Create an event within ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -685,7 +685,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Start an investigation within ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -718,7 +718,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Upload a spearphish attempt to ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -745,7 +745,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Upload (and parse) a file to ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -774,7 +774,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Query ThreatQ for an object's relationships
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -810,7 +810,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Create a signature within ThreatQ
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -841,7 +841,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 # File: __init__.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -2,7 +2,7 @@
 # File: __init__.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/api/indicator_parser.py
+++ b/api/indicator_parser.py
@@ -2,7 +2,7 @@
 # File: indicator_parser.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/api/tq_mappings.py
+++ b/api/tq_mappings.py
@@ -2,7 +2,7 @@
 # File: tq_mappings.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/api/utils.py
+++ b/api/utils.py
@@ -2,7 +2,7 @@
 # File: utils.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Verify ThreatQuotient server certificates by default.

--- a/threatq.json
+++ b/threatq.json
@@ -59,7 +59,7 @@
         "trust_ssl": {
             "description": "Trust SSL Certificate?",
             "data_type": "boolean",
-            "default": true,
+            "default": false,
             "order": 4
         }
     },

--- a/threatq.json
+++ b/threatq.json
@@ -19,7 +19,7 @@
     ],
     "package_name": "threatq",
     "type": "information",
-    "license": "Copyright (c) 2016-2025 ThreatQuotient, Inc.",
+    "license": "Copyright (c) 2016-2026 ThreatQuotient, Inc.",
     "main_module": "threatq_connector.py",
     "app_version": "2.4.0",
     "utctime_updated": "2022-12-11T22:11:10.000000Z",
@@ -1970,5 +1970,11 @@
             ],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/threatq_connector.py
+++ b/threatq_connector.py
@@ -1,7 +1,7 @@
 # File: threatq_connector.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatq_consts.py
+++ b/threatq_consts.py
@@ -1,7 +1,7 @@
 # File: threatq_consts.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatq_view_summarize.html
+++ b/threatq_view_summarize.html
@@ -16,7 +16,7 @@
   <!-- Main Start Block -->
   <!-- File: threatq_view_summarize.html
     ThreatQuotient Proprietary and Confidential
-    Copyright (c) 2016-2025 ThreatQuotient, Inc.
+    Copyright (c) 2016-2026 ThreatQuotient, Inc.
 
     NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
     The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatq_view_uploaded.html
+++ b/threatq_view_uploaded.html
@@ -16,7 +16,7 @@
   <!-- Main Start Block -->
   <!-- File: threatq_view_uploaded.html
     ThreatQuotient Proprietary and Confidential
-    Copyright (c) 2016-2025 ThreatQuotient, Inc.
+    Copyright (c) 2016-2026 ThreatQuotient, Inc.
 
     NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
     The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatq_views.py
+++ b/threatq_views.py
@@ -1,7 +1,7 @@
 # File: threatq_views.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatqsdk/__init__.py
+++ b/threatqsdk/__init__.py
@@ -23,7 +23,6 @@ from datetime import datetime
 from logging import getLogger
 
 import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 # import all of the child modules so consumers can easily access them
 from . import (
@@ -60,9 +59,6 @@ _logger = getLogger(__name__)
 
 VERSION = "1.6.4-pmod"
 
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-
-
 class Threatq:
     """A connection to the ThreatQuotient API.
     The auth and private parameters are passed directly to a new
@@ -84,7 +80,7 @@ class Threatq:
         In the format ``https://host.name:port``
     """
 
-    def __init__(self, threatq_host, auth, private=False, verify=False, proxy=None):
+    def __init__(self, threatq_host, auth, private=False, verify=True, proxy=None):
         self.statusinfo = None
 
         host_match = re.compile(r"^(\w+://)?([A-Z\d\-\.:]+)", re.IGNORECASE)

--- a/threatqsdk/__init__.py
+++ b/threatqsdk/__init__.py
@@ -2,7 +2,7 @@
 # File: __init__.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.
@@ -58,6 +58,7 @@ __all__ = [
 _logger = getLogger(__name__)
 
 VERSION = "1.6.4-pmod"
+
 
 class Threatq:
     """A connection to the ThreatQuotient API.

--- a/threatqsdk/authentication.py
+++ b/threatqsdk/authentication.py
@@ -2,7 +2,7 @@
 # File: authentication.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatqsdk/bulk_object.py
+++ b/threatqsdk/bulk_object.py
@@ -2,7 +2,7 @@
 # File: bulk_object.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatqsdk/event.py
+++ b/threatqsdk/event.py
@@ -2,7 +2,7 @@
 # File: event.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatqsdk/exceptions.py
+++ b/threatqsdk/exceptions.py
@@ -2,7 +2,7 @@
 # File: exceptions.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatqsdk/file.py
+++ b/threatqsdk/file.py
@@ -2,7 +2,7 @@
 # File: file.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatqsdk/source.py
+++ b/threatqsdk/source.py
@@ -2,7 +2,7 @@
 # File: source.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.

--- a/threatqsdk/tqobject.py
+++ b/threatqsdk/tqobject.py
@@ -2,7 +2,7 @@
 # File: tqobject.py
 #
 # ThreatQuotient Proprietary and Confidential
-# Copyright (c) 2016-2025 ThreatQuotient, Inc. All rights reserved.
+# Copyright (c) 2016-2026 ThreatQuotient, Inc. All rights reserved.
 #
 # NOTICE: All information contained herein, is, and remains the property of ThreatQuotient, Inc.
 # The intellectual and technical concepts contained herein are proprietary to ThreatQuotient, Inc.


### PR DESCRIPTION
## Summary

- Verify ThreatQuotient server certificates by default for new assets.
- Retain **Trust SSL Certificate?** as an explicit opt-out for self-signed or private-CA deployments.
- Make the bundled SDK secure by default and restore standard warnings when an operator deliberately disables verification.
- Refresh central hooks to `dev-cicd-tools v2.2.4` and include the generated empty pip39/pip313 metadata.

## Tracking

- PAPP: PAPP-38095
- PSAAS: PSAAS-31380
- Provenance: VULN-94105, FS-2259

## Breaking change

Assets that rely on an untrusted ThreatQuotient certificate must explicitly enable **Trust SSL Certificate?** or install the issuing CA.

## Validation

- `python3.13 -m py_compile threatq_connector.py threatqsdk/__init__.py`
- Refreshed v2.2.4 `static-tests` passed after package metadata generation.
- Full isolated Python 3.13 all-files pre-commit gate, including package, static, Semgrep, documentation, NOTICE, and release-note hooks.

Written by Codex.
